### PR TITLE
update path for binary code

### DIFF
--- a/lib/captcha.ex
+++ b/lib/captcha.ex
@@ -1,6 +1,6 @@
 defmodule Captcha do
   def get() do
-    Port.open({:spawn, Path.join(Path.dirname(__ENV__.file), "../priv/captcha")}, [:binary])
+    Port.open({:spawn, Path.join(:code.priv_dir(:captcha), "captcha")}, [:binary])
 
     receive do
       {_, {:data, data}} ->

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Captcha.Mixfile do
      start_permanent: Mix.env == :prod,
      compilers: [:make, :elixir, :app],
      description: description(),
-     aliases: aliases,
+     aliases: aliases(),
      package: package(),
      deps: deps()]
   end

--- a/test/elixir_captcha_test.exs
+++ b/test/elixir_captcha_test.exs
@@ -2,7 +2,7 @@ defmodule CaptchaTest do
   use ExUnit.Case
   doctest Captcha
 
-  test "the truth" do
-    assert 1 + 1 == 2
+  test "generate image success" do
+    assert {:ok, _, _} = Captcha.get()
   end
 end


### PR DESCRIPTION
I'm using this library in my project, I always built a release on a server and then deployed on other servers.

when I call `Captcha.get()`, I saw that it uses `captcha`'s path is under `deps` in the my project source code, not the correct path.

So I created this pr.