### PR TITLE
allow customize Port.open receive timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 ## Usage
 
 ```elixir
+# allow customize receive timeout, default: 10_000
 case Captcha.get() do
   {:ok, text, img_binary } ->
     # save text in session, then send img to client

--- a/lib/captcha.ex
+++ b/lib/captcha.ex
@@ -1,5 +1,5 @@
 defmodule Captcha do
-  def get(timeout \\ 10_000) do
+  def get(timeout \\ 50_000) do
     Port.open({:spawn, Path.join(:code.priv_dir(:captcha), "captcha")}, [:binary])
 
     # Allow set receive timeout

--- a/lib/captcha.ex
+++ b/lib/captcha.ex
@@ -8,7 +8,7 @@ defmodule Captcha do
         {:ok, text, img }
       other -> other
     after
-      1_000 -> { :timeout }
+      10_000 -> { :timeout }
     end
   end
 end

--- a/lib/captcha.ex
+++ b/lib/captcha.ex
@@ -1,14 +1,16 @@
 defmodule Captcha do
-  def get() do
+  def get(timeout \\ 10_000) do
     Port.open({:spawn, Path.join(:code.priv_dir(:captcha), "captcha")}, [:binary])
 
+    # Allow set receive timeout
     receive do
       {_, {:data, data}} ->
         <<text::bytes-size(5), img::binary>> = data
         {:ok, text, img }
+
       other -> other
-    after
-      10_000 -> { :timeout }
+    after timeout ->
+      { :timeout }
     end
   end
 end

--- a/lib/captcha.ex
+++ b/lib/captcha.ex
@@ -1,5 +1,6 @@
 defmodule Captcha do
-  def get(timeout \\ 50_000) do
+  # allow customize receive timeout, default: 10_000
+  def get(timeout \\ 1_000) do
     Port.open({:spawn, Path.join(:code.priv_dir(:captcha), "captcha")}, [:binary])
 
     # Allow set receive timeout
@@ -10,7 +11,7 @@ defmodule Captcha do
 
       other -> other
     after timeout ->
-      { :timeout }
+      {:timeout}
     end
   end
 end


### PR DESCRIPTION
I use elixir-captcha deploy at Heroku, the default receive time 1_000 always timed out, I hope to add a custom timeout setting.  😄 

here is:  https://elixir-mipha.herokuapp.com/join