### PR TITLE
use System.cmd instead of Port.open

### DIFF
--- a/lib/captcha.ex
+++ b/lib/captcha.ex
@@ -1,17 +1,12 @@
 defmodule Captcha do
-  # allow customize receive timeout, default: 10_000
   def get(timeout \\ 1_000) do
-    Port.open({:spawn, Path.join(:code.priv_dir(:captcha), "captcha")}, [:binary])
-
-    # Allow set receive timeout
-    receive do
-      {_, {:data, data}} ->
+    case System.cmd(Path.join(Path.dirname(__ENV__.file), "../priv/captcha"), []) do
+      {data, 0} ->
         <<text::bytes-size(5), img::binary>> = data
-        {:ok, text, img }
+        {:ok, text, img}
 
-      other -> other
-    after timeout ->
-      {:timeout}
+      other ->
+        :error
     end
   end
 end


### PR DESCRIPTION
Try to fix #3, but I ignore the `timeout` parameter