### PR TITLE
Fix parameter type of `make clean` in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ end
 
 defmodule Mix.Tasks.Clean.Make do
   def run(_) do
-    {result, _error_code} = System.cmd("make", ['clean'], stderr_to_stdout: true)
+    {result, _error_code} = System.cmd("make", ["clean"], stderr_to_stdout: true)
     Mix.shell.info result
 
     :ok


### PR DESCRIPTION
Hello, I have found a little bug when i compile `elixir-captcha` on Windows.
And i fixed it.

With the wrong argument `'clean'` (`"clean"` correctly), Elixir will raise:
>** (ArgumentError) all arguments for System.cmd/3 must be binaries
>   (elixir 1.13.4) lib/system.ex:1035: System.cmd/3