### PR TITLE
Port build to elixir_make

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,33 +1,15 @@
-defmodule Mix.Tasks.Compile.Make do
-  def run(_) do
-    {result, _error_code} = System.cmd("make", [], stderr_to_stdout: true)
-    Mix.shell.info result
-
-    :ok
-  end
-end
-
-defmodule Mix.Tasks.Clean.Make do
-  def run(_) do
-    {result, _error_code} = System.cmd("make", ["clean"], stderr_to_stdout: true)
-    Mix.shell.info result
-
-    :ok
-  end
-end
-
 defmodule Captcha.Mixfile do
   use Mix.Project
 
   def project do
     [app: :captcha,
      version: "0.1.0",
-     elixir: "~> 1.3",
+     elixir: "~> 1.9",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     compilers: [:make, :elixir, :app],
+     compilers: [:elixir_make, :elixir, :app],
+     make_clean: ["clean"],
      description: description(),
-     aliases: aliases(),
      package: package(),
      deps: deps()]
   end
@@ -36,7 +18,7 @@ defmodule Captcha.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   # Dependencies can be Hex packages:
@@ -49,11 +31,10 @@ defmodule Captcha.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:ex_doc, ">= 0.0.0", only: :dev}]
-  end
-
-  defp aliases do
-    [clean: ["clean", "clean.make"]]
+    [
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:elixir_make, "~> 0.8", runtime: false}
+    ]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,5 @@
-%{"earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]}}
+%{
+  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], [], "hexpm", "6709251dd10e70cca0d50be8a25adc38c701b39eac2da3b1c166e3e7e4d358ed"},
+  "elixir_make": {:hex, :elixir_make, "0.8.4", "4960a03ce79081dee8fe119d80ad372c4e7badb84c493cc75983f9d3bc8bde0f", [:mix], [{:castore, "~> 0.1 or ~> 1.0", [hex: :castore, repo: "hexpm", optional: true]}, {:certifi, "~> 2.0", [hex: :certifi, repo: "hexpm", optional: true]}], "hexpm", "6e7f1d619b5f61dfabd0a20aa268e575572b542ac31723293a4c1a567d5ef040"},
+  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "e5ea59f50ecdfe4cc755808450dafe35221d5a0f4a31c42e80a7188eca570e4c"},
+}


### PR DESCRIPTION
Ports build to elixir_make, fixes build failures on BSDs due to hardcoded "make".

* Minimum Elixir version bumped to 1.9 (same as elixir_make)
* Tested with:
  - Elixir 1.9.4/OTP 22 - Arch Linux (passes mix test)
  - Elixir 1.14.5/OTP 23 - Arch Linux (passes mix test)
  - Elixir 1.17.3/OTP 26 - Arch Linux (passes mix test)
  - Elixir 1.17.2/OTP 26 - OpenBSD 7.6 (passes mix test, a slightly modified [version](https://git.pleroma.social/pleroma/elixir-libraries/elixir-captcha) from Pleroma works)

Fixes #8 